### PR TITLE
fixed mobile uv half2 bug

### DIFF
--- a/Assets/FaceMesh/Shader/Preprocess.shader
+++ b/Assets/FaceMesh/Shader/Preprocess.shader
@@ -13,7 +13,7 @@ Shader "Hidden/MediaPipe/FaceMesh/Preprocess"
     float4x4 _Xform;
 
     float4 Fragment(float4 vertex : SV_Position,
-                    float2 uv : TEXCOORD0) : SV_Target
+                    half2 uv : TEXCOORD0) : SV_Target
     {
         uv = mul(_Xform, float4(uv, 0, 1)).xy;
         return tex2D(_MainTex, uv);


### PR DESCRIPTION
Precision misalignment on iOS results in errors. need half2 not float2
```
struct v2f_img
{
    float4 pos : SV_POSITION;
    half2 uv : TEXCOORD0;
    UNITY_VERTEX_INPUT_INSTANCE_ID
    UNITY_VERTEX_OUTPUT_STEREO
};
```